### PR TITLE
fix: GradientCenter bug

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/i2k2020/ops/GradientCenter.java
+++ b/src/main/java/org/janelia/saalfeldlab/i2k2020/ops/GradientCenter.java
@@ -68,7 +68,7 @@ public class GradientCenter<T extends RealType<T> & NativeType<T>> implements Co
 
 		while (c.hasNext()) {
 			final T t = c.next();
-			t.setReal((b.next().getRealDouble() - a.next().getRealDouble()) * norm);
+			t.setReal((b.next().getRealDouble() - a.next().getRealDouble()) / norm);
 		}
 	}
 }


### PR DESCRIPTION
Central differences should be divided, not multiplied by 2.

Screenshot of before (left) and after (right) this commit.

![Screenshot from 2024-10-16 11-21-52](https://github.com/user-attachments/assets/b7528a48-f586-48dd-806c-9fb3618788ad)

There may be other issues as well
